### PR TITLE
Elimiar pestaña cursos de index.html

### DIFF
--- a/frontend/app/index.html
+++ b/frontend/app/index.html
@@ -39,9 +39,9 @@
           <li class="rol-asociado" ng-class="{active: controlador === 'AsociadoCtrl'}"><a href="#/asociados">{{::menu.asociados}}</a></li>
           <li class="rol-tecnico"><a href="#/tecnico/asociados">{{::menu.asociados}}</a></li>
           <li class="rol-asociado" ng-class="{active: controlador === 'GrupoCtrl'}"><a href="#/grupo/{{::menu.codigoGrupo}}">{{::menu.migrupo}}</a></li>
-          <li class="rol-asociado" ng-class="{active: seccion === 'cursos'}"><a href="#/cursos">{{::menu.cursos}}</a></li>
+          <!--<li class="rol-asociado" ng-class="{active: seccion === 'cursos'}"><a href="#/cursos">{{::menu.cursos}}</a></li>-->
           <li class="rol-lluerna"><a href="#/lluerna/miembros">{{::menu.miembros}}</a></li>
-          <li class="rol-lluerna"><a href="#/lluerna/cursos">{{::menu.cursos}}</a></li>
+          <!--<li class="rol-lluerna"><a href="#/lluerna/cursos">{{::menu.cursos}}</a></li>-->
           <li class="rol-asociado" ng-class="{active: controlador === 'ActividadesListadoCtrl' || controlador === 'ActividadesDetalleCtrl'}">
             <a href="#/actividades">{{::menu.actividades}}</a>
           </li>


### PR DESCRIPTION
Closes https://github.com/fev/cudu/issues/57
https://github.com/fev/cudu/issues/57: <AC08 Llevar pestanya “Cursos” del menú superior.>
Solamente se comenta la pestaña de index.html. El resto de funcionalidades se dejan sin comentar para futuros usos.