### PR TITLE
Fix cambiar genero merge

### DIFF
--- a/backend/src/main/java/org/scoutsfev/cudu/domain/Genero.java
+++ b/backend/src/main/java/org/scoutsfev/cudu/domain/Genero.java
@@ -4,7 +4,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum Genero {
     Masculino('M'),
-    Femenino('F');
+    Femenino('F'),
+    NoBinario ('N');
 
     private final char tipo;
 

--- a/backend/src/main/resources/db/migration/V12.0__asociado_alter_colum_sexo.sql
+++ b/backend/src/main/resources/db/migration/V12.0__asociado_alter_colum_sexo.sql
@@ -1,2 +1,1 @@
 alter table asociado rename column sexo to genero;
-alter table asociado alter column genero type character(2);

--- a/backend/src/main/resources/messages_ca.properties
+++ b/backend/src/main/resources/messages_ca.properties
@@ -184,6 +184,7 @@ asociado.mostrar=Mostrar
 asociado.otrosFiltros=Altres filtres
 asociado.municipio=Municipi
 asociado.ningunCursoRealizado=Ningún curs realitzat
+asociado.noBinario=No Binari
 asociado.noHayCargos=No hi ha càrrecs.
 asociado.nombre=Nom
 asociado.nombreMadre=Nom Mare

--- a/backend/src/main/resources/messages_es.properties
+++ b/backend/src/main/resources/messages_es.properties
@@ -184,6 +184,7 @@ asociado.mostrar=Mostrar
 asociado.otrosFiltros=Otros filtros
 asociado.municipio=Municipio
 asociado.ningunCursoRealizado=Ningún curso realizado
+asociado.noBinario=No Binario
 asociado.noHayCargos=No hay cargos.
 asociado.nombre=Nombre
 asociado.nombreMadre=Nombre Madre


### PR DESCRIPTION
Estos son todos los comits que @AmaiaMCastanos había hecho en la rama cambiar-genero (antes de que yo empezara el merge con la master): https://github.com/fev/cudu/compare/a8e85fb..df2d18d

Y de aquí te faltaban algunas cosillas que no me habia dado cuenta y que he arreglado en algunos comits ahora:
- Ya no hace falta que el género tenga dos caracteres en la bd.
- Faltaba añadir la traducción de noBinario en Catalán.

Esta PR arregla el merge de las funcionalidades cambia-genero y proteccion-infancia.